### PR TITLE
Support secondary screen memory on QL

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -9718,7 +9718,7 @@ Bit	Purpose
 
 	unsigned char *memoria_pantalla_ql;
 
-	memoria_pantalla_ql=&memoria_ql[0x20000];
+	memoria_pantalla_ql=&memoria_ql[0x20000 + ((mc_stat & 0x80) << 8)];
 
 	//int temp_cuenta=0;
 


### PR DESCRIPTION
If bit 7 in mc_stat is set, display the secondary screen memory at $28000 instead of $20000.