### PR TITLE
Tbblue core2.00.26 clip windows

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -58,3 +58,12 @@ Makefile
 .vscode/
 .zxdbg/
 cmake-build-debug/
+
+# Linux configure+make+install in src directory does generate these files for me:
+src/compileoptions.h
+src/zesarux
+src/install.sh
+
+# KDevelop IDE does produce these local folders and files:
+.kdev4/
+*.kdev4

--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -2554,11 +2554,7 @@ void menu_debug_tsconf_tbblue_videoregisters(MENU_ITEM_PARAMETERS)
 
 					/*
 					z80_byte clip_window_layer2[4];
-z80_byte clip_window_layer2_index;
-
 z80_byte clip_window_sprites[4];
-z80_byte clip_window_sprites_index;
-
 z80_byte clip_window_ula[4];
 					*/
 

--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -2566,17 +2566,33 @@ z80_byte clip_window_ula[4];
 					sprintf (texto_buffer,"Layer2:  X=%3d-%3d Y=%3d-%3d",
 					clip_window_layer2[0],clip_window_layer2[1],clip_window_layer2[2],clip_window_layer2[3]);
 					//menu_escribe_linea_opcion(linea++,-1,1,texto_buffer);
-					zxvision_print_string_defaults(&ventana,1,linea++,texto_buffer);
+					zxvision_print_string_defaults(&ventana,1,linea,texto_buffer);
+                    //overwrite currently selected clip-window index value by "selection" graphics
+                    const static int clip_index_string_pos_x[4] = { 11, 15, 21, 25};
+                    int clip_select_x = clip_index_string_pos_x[tbblue_get_clip_window_layer2_index()];
+                    texto_buffer[clip_select_x+3] = 0;      // display only three digits in new colour
+					zxvision_print_string(&ventana,1+clip_select_x,linea++,
+                                          ESTILO_GUI_TINTA_NORMAL,ESTILO_GUI_PAPEL_SELECCIONADO,0,texto_buffer+clip_select_x);
 
 					sprintf (texto_buffer,"Sprites: X=%3d-%3d Y=%3d-%3d",
 					clip_window_sprites[0],clip_window_sprites[1],clip_window_sprites[2],clip_window_sprites[3]);
 					//menu_escribe_linea_opcion(linea++,-1,1,texto_buffer);
-					zxvision_print_string_defaults(&ventana,1,linea++,texto_buffer);
+					zxvision_print_string_defaults(&ventana,1,linea,texto_buffer);
+                    //overwrite currently selected clip-window index value by "selection" graphics
+                    clip_select_x = clip_index_string_pos_x[tbblue_get_clip_window_sprites_index()];
+                    texto_buffer[clip_select_x+3] = 0;      // display only three digits in new colour
+					zxvision_print_string(&ventana,1+clip_select_x,linea++,
+                                          ESTILO_GUI_TINTA_NORMAL,ESTILO_GUI_PAPEL_SELECCIONADO,0,texto_buffer+clip_select_x);
 
 					sprintf (texto_buffer,"ULA:     X=%3d-%3d Y=%3d-%3d",
 					clip_window_ula[0],clip_window_ula[1],clip_window_ula[2],clip_window_ula[3]);
 					//menu_escribe_linea_opcion(linea++,-1,1,texto_buffer);
-					zxvision_print_string_defaults(&ventana,1,linea++,texto_buffer);
+					zxvision_print_string_defaults(&ventana,1,linea,texto_buffer);
+                    //overwrite currently selected clip-window index value by "selection" graphics
+                    clip_select_x = clip_index_string_pos_x[tbblue_get_clip_window_ula_index()];
+                    texto_buffer[clip_select_x+3] = 0;      // display only three digits in new colour
+					zxvision_print_string(&ventana,1+clip_select_x,linea++,
+                                          ESTILO_GUI_TINTA_NORMAL,ESTILO_GUI_PAPEL_SELECCIONADO,0,texto_buffer+clip_select_x);
 
 					linea++;
 					sprintf (texto_buffer,"Offset Windows:");

--- a/src/menu_items.c
+++ b/src/menu_items.c
@@ -2434,7 +2434,7 @@ void menu_debug_tsconf_tbblue_videoregisters(MENU_ITEM_PARAMETERS)
 
 	if (MACHINE_IS_TBBLUE) {
 		yventana=2;
-		alto_ventana=19;
+		alto_ventana=20;
 	}
 
 	else {
@@ -2553,9 +2553,10 @@ void menu_debug_tsconf_tbblue_videoregisters(MENU_ITEM_PARAMETERS)
 
 
 					/*
-					z80_byte clip_window_layer2[4];
-z80_byte clip_window_sprites[4];
-z80_byte clip_window_ula[4];
+					z80_byte clip_windows[TBBLUE_CLIP_WINDOW_LAYER2][4];
+z80_byte clip_windows[TBBLUE_CLIP_WINDOW_SPRITES][4];
+z80_byte clip_windows[TBBLUE_CLIP_WINDOW_ULA][4];
+z80_byte clip_windows[TBBLUE_CLIP_WINDOW_TILEMAP][4];
 					*/
 
 					linea++;
@@ -2564,7 +2565,7 @@ z80_byte clip_window_ula[4];
 					zxvision_print_string_defaults(&ventana,1,linea++,texto_buffer);
 
 					sprintf (texto_buffer,"Layer2:  X=%3d-%3d Y=%3d-%3d",
-					clip_window_layer2[0],clip_window_layer2[1],clip_window_layer2[2],clip_window_layer2[3]);
+					clip_windows[TBBLUE_CLIP_WINDOW_LAYER2][0],clip_windows[TBBLUE_CLIP_WINDOW_LAYER2][1],clip_windows[TBBLUE_CLIP_WINDOW_LAYER2][2],clip_windows[TBBLUE_CLIP_WINDOW_LAYER2][3]);
 					//menu_escribe_linea_opcion(linea++,-1,1,texto_buffer);
 					zxvision_print_string_defaults(&ventana,1,linea,texto_buffer);
                     //overwrite currently selected clip-window index value by "selection" graphics
@@ -2575,7 +2576,7 @@ z80_byte clip_window_ula[4];
                                           ESTILO_GUI_TINTA_NORMAL,ESTILO_GUI_PAPEL_SELECCIONADO,0,texto_buffer+clip_select_x);
 
 					sprintf (texto_buffer,"Sprites: X=%3d-%3d Y=%3d-%3d",
-					clip_window_sprites[0],clip_window_sprites[1],clip_window_sprites[2],clip_window_sprites[3]);
+					clip_windows[TBBLUE_CLIP_WINDOW_SPRITES][0],clip_windows[TBBLUE_CLIP_WINDOW_SPRITES][1],clip_windows[TBBLUE_CLIP_WINDOW_SPRITES][2],clip_windows[TBBLUE_CLIP_WINDOW_SPRITES][3]);
 					//menu_escribe_linea_opcion(linea++,-1,1,texto_buffer);
 					zxvision_print_string_defaults(&ventana,1,linea,texto_buffer);
                     //overwrite currently selected clip-window index value by "selection" graphics
@@ -2585,11 +2586,21 @@ z80_byte clip_window_ula[4];
                                           ESTILO_GUI_TINTA_NORMAL,ESTILO_GUI_PAPEL_SELECCIONADO,0,texto_buffer+clip_select_x);
 
 					sprintf (texto_buffer,"ULA:     X=%3d-%3d Y=%3d-%3d",
-					clip_window_ula[0],clip_window_ula[1],clip_window_ula[2],clip_window_ula[3]);
+					clip_windows[TBBLUE_CLIP_WINDOW_ULA][0],clip_windows[TBBLUE_CLIP_WINDOW_ULA][1],clip_windows[TBBLUE_CLIP_WINDOW_ULA][2],clip_windows[TBBLUE_CLIP_WINDOW_ULA][3]);
 					//menu_escribe_linea_opcion(linea++,-1,1,texto_buffer);
 					zxvision_print_string_defaults(&ventana,1,linea,texto_buffer);
                     //overwrite currently selected clip-window index value by "selection" graphics
                     clip_select_x = clip_index_string_pos_x[tbblue_get_clip_window_ula_index()];
+                    texto_buffer[clip_select_x+3] = 0;      // display only three digits in new colour
+					zxvision_print_string(&ventana,1+clip_select_x,linea++,
+                                          ESTILO_GUI_TINTA_NORMAL,ESTILO_GUI_PAPEL_SELECCIONADO,0,texto_buffer+clip_select_x);
+
+					sprintf (texto_buffer,"Tilemap: X=%3d-%3d Y=%3d-%3d",
+					clip_windows[TBBLUE_CLIP_WINDOW_TILEMAP][0],clip_windows[TBBLUE_CLIP_WINDOW_TILEMAP][1],clip_windows[TBBLUE_CLIP_WINDOW_TILEMAP][2],clip_windows[TBBLUE_CLIP_WINDOW_TILEMAP][3]);
+					//menu_escribe_linea_opcion(linea++,-1,1,texto_buffer);
+					zxvision_print_string_defaults(&ventana,1,linea,texto_buffer);
+                    //overwrite currently selected clip-window index value by "selection" graphics
+                    clip_select_x = clip_index_string_pos_x[tbblue_get_clip_window_tilemap_index()];
                     texto_buffer[clip_select_x+3] = 0;      // display only three digits in new colour
 					zxvision_print_string(&ventana,1+clip_select_x,linea++,
                                           ESTILO_GUI_TINTA_NORMAL,ESTILO_GUI_PAPEL_SELECCIONADO,0,texto_buffer+clip_select_x);

--- a/src/remote.c
+++ b/src/remote.c
@@ -825,8 +825,8 @@ struct s_items_ayuda items_ayuda[]={
   {"speech-empty-fifo",NULL,NULL,"Empty speech fifo"},
   {"speech-send",NULL,"message","Sends message to speech"},
 
-  {"tbblue-get-clipwindow",NULL,"ula|layer2|sprite","Get clip window parameters. You need to tell which clip window. Only allowed on machine TBBlue"},
-  {"tbblue-set-clipwindow",NULL,"ula|layer2|sprite x1 x2 y1 y2","Set clip window parameters. You need to tell which clip window. Only allowed on machine TBBlue"},
+  {"tbblue-get-clipwindow",NULL,"ula|layer2|sprite|tilemap","Get clip window parameters. You need to tell which clip window. Only allowed on machine TBBlue"},
+  {"tbblue-set-clipwindow",NULL,"ula|layer2|sprite|tilemap x1 x2 y1 y2","Set clip window parameters. You need to tell which clip window. Only allowed on machine TBBlue"},
 
 
  {"tbblue-get-palette",NULL,"ula|layer2|sprite first|second index [items]","Get palette colours at index, if not specified items parameters, returns only one. You need to tell which palette. Returned values are in hexadecimal format. Only allowed on machine TBBlue"},
@@ -3071,29 +3071,23 @@ int return_internal_pointer(char *s,z80_byte **puntero)
 
 
 //Retorna puntero a array de clip window, segun 
-//tipo : ula|layer2|sprite
+//tipo : ula|layer2|sprite|tilemap
 //Retorna NULL si hay algun error
 z80_byte *remote_return_clipwindow(char *tipo)
 {
-
-  /*
-
-z80_byte clip_window_layer2[4];
-
-z80_byte clip_window_sprites[4];
-
-z80_byte clip_window_ula[4];
-
-*/
+//z80_byte clip_windows[4][4];
 
   if (!strcmp(tipo,"ula")) {
-    return clip_window_ula;
+    return clip_windows[TBBLUE_CLIP_WINDOW_ULA];
   }
   else   if (!strcmp(tipo,"layer2")) {
-    return clip_window_layer2;
+    return clip_windows[TBBLUE_CLIP_WINDOW_LAYER2];
   }
   else   if (!strcmp(tipo,"sprite")) {
-    return clip_window_sprites;
+    return clip_windows[TBBLUE_CLIP_WINDOW_SPRITES];
+  }
+  else   if (!strcmp(tipo,"tilemap")) {
+    return clip_windows[TBBLUE_CLIP_WINDOW_TILEMAP];
   }
 
   return NULL;

--- a/src/tbblue.c
+++ b/src/tbblue.c
@@ -619,17 +619,66 @@ Clip window registers
   bit 1 - reset the sprite clip index.
   bit 0 - reset the Layer 2 clip index.
 
+(R) 0x1C (28) => Clip Window control
+  bits 7-6 = Reserved
+  bit 5-4 - Layer 2 clip index.
+  bit 3-2 - sprite clip index.
+  bit 1-0 - ULA/LoRes clip index.
 */
 
 z80_byte clip_window_layer2[4];
-z80_byte clip_window_layer2_index;
+#define TBBLUE_CLIP_WINDOW_LAYER2_INDEX_SHIFT   4
+#define TBBLUE_CLIP_WINDOW_LAYER2_INDEX_MASK    (3<<TBBLUE_CLIP_WINDOW_LAYER2_INDEX_SHIFT)
+
+z80_byte tbblue_get_clip_window_layer2_index(void) {
+    return (tbblue_registers[28] & TBBLUE_CLIP_WINDOW_LAYER2_INDEX_MASK)>>TBBLUE_CLIP_WINDOW_LAYER2_INDEX_SHIFT;
+}
+
+void tbblue_inc_clip_window_layer2_index(void) {
+    z80_byte inc_index = tbblue_registers[28] + (1<<TBBLUE_CLIP_WINDOW_LAYER2_INDEX_SHIFT);
+    tbblue_registers[28] &= ~TBBLUE_CLIP_WINDOW_LAYER2_INDEX_MASK;
+    tbblue_registers[28] |= inc_index & TBBLUE_CLIP_WINDOW_LAYER2_INDEX_MASK;
+}
+
+void tbblue_reset_clip_window_layer2_index(void) {
+    tbblue_registers[28] &= ~TBBLUE_CLIP_WINDOW_LAYER2_INDEX_MASK;
+}
 
 z80_byte clip_window_sprites[4];
-z80_byte clip_window_sprites_index;
+#define TBBLUE_CLIP_WINDOW_SPRITES_INDEX_SHIFT   2
+#define TBBLUE_CLIP_WINDOW_SPRITES_INDEX_MASK    (3<<TBBLUE_CLIP_WINDOW_SPRITES_INDEX_SHIFT)
+
+z80_byte tbblue_get_clip_window_sprites_index(void) {
+    return (tbblue_registers[28] & TBBLUE_CLIP_WINDOW_SPRITES_INDEX_MASK)>>TBBLUE_CLIP_WINDOW_SPRITES_INDEX_SHIFT;
+}
+
+void tbblue_inc_clip_window_sprites_index(void) {
+    z80_byte inc_index = tbblue_registers[28] + (1<<TBBLUE_CLIP_WINDOW_SPRITES_INDEX_SHIFT);
+    tbblue_registers[28] &= ~TBBLUE_CLIP_WINDOW_SPRITES_INDEX_MASK;
+    tbblue_registers[28] |= inc_index & TBBLUE_CLIP_WINDOW_SPRITES_INDEX_MASK;
+}
+
+void tbblue_reset_clip_window_sprites_index(void) {
+    tbblue_registers[28] &= ~(TBBLUE_CLIP_WINDOW_SPRITES_INDEX_MASK);
+}
 
 z80_byte clip_window_ula[4];
-z80_byte clip_window_ula_index;
+#define TBBLUE_CLIP_WINDOW_ULA_INDEX_SHIFT   0
+#define TBBLUE_CLIP_WINDOW_ULA_INDEX_MASK    (3<<TBBLUE_CLIP_WINDOW_ULA_INDEX_SHIFT)
 
+z80_byte tbblue_get_clip_window_ula_index(void) {
+    return (tbblue_registers[28] & TBBLUE_CLIP_WINDOW_ULA_INDEX_MASK)>>TBBLUE_CLIP_WINDOW_ULA_INDEX_SHIFT;
+}
+
+void tbblue_inc_clip_window_ula_index(void) {
+    z80_byte inc_index = tbblue_registers[28] + (1<<TBBLUE_CLIP_WINDOW_ULA_INDEX_SHIFT);
+    tbblue_registers[28] &= ~TBBLUE_CLIP_WINDOW_ULA_INDEX_MASK;
+    tbblue_registers[28] |= inc_index & TBBLUE_CLIP_WINDOW_ULA_INDEX_MASK;
+}
+
+void tbblue_reset_clip_window_ula_index(void) {
+    tbblue_registers[28] &= ~(TBBLUE_CLIP_WINDOW_ULA_INDEX_MASK);
+}
 
 //Forzar desde menu a desactivar capas 
 z80_bit tbblue_force_disable_layer_ula={0};
@@ -2564,9 +2613,6 @@ void tbblue_reset_common(void)
 	tbblue_registers[22]=0;
 	tbblue_registers[23]=0;
 
-	tbblue_registers[24]=191;
-	tbblue_registers[25]=191;
-	tbblue_registers[26]=191;
 	tbblue_registers[28]=0;
 
 	tbblue_registers[30]=0;
@@ -2597,9 +2643,6 @@ void tbblue_reset_common(void)
 	clip_window_ula[1]=255;
 	clip_window_ula[2]=0;
 	clip_window_ula[3]=191;	
-
-
-	clip_window_layer2_index=clip_window_sprites_index=clip_window_ula_index=0;
 
 
 
@@ -2951,18 +2994,65 @@ void tbblue_set_value_port_position(z80_byte index_position,z80_byte value)
 	z80_byte last_register_67=tbblue_registers[67];
 	
 
-	if (index_position==3) {
-		//Controlar caso especial
-		//(W) 0x03 (03) => Set machine type, only in IPL or config mode
-		//   		bits 2-0 = Machine type:
-		//      		000 = Config mode
-		z80_byte machine_type=tbblue_registers[3]&7;
+    switch(index_position) {
+        case 3:
+        {
+            //Controlar caso especial
+            //(W) 0x03 (03) => Set machine type, only in IPL or config mode
+            //   		bits 2-0 = Machine type:
+            //      		000 = Config mode
+            z80_byte machine_type=tbblue_registers[3]&7;
 
-		if (!(machine_type==0 || tbblue_bootrom.v)) {
-			debug_printf(VERBOSE_DEBUG,"Can not change machine type (to %02XH) while in non config mode or non IPL mode",value);
-			return;
-		}
-	}
+            if (!(machine_type==0 || tbblue_bootrom.v)) {
+                debug_printf(VERBOSE_DEBUG,"Can not change machine type (to %02XH) while in non config mode or non IPL mode",value);
+                return;
+            }
+        }
+        break;
+
+        case 28:
+        /*
+        (W) 0x1C (28) => Clip Window control
+            bits 7-3 = Reserved, must be 0
+            bit 2 - reset the ULA/LoRes clip index.
+            bit 1 - reset the sprite clip index.
+            bit 0 - reset the Layer 2 clip index.
+        */
+
+			if (value&1) tbblue_reset_clip_window_layer2_index();
+			if (value&2) tbblue_reset_clip_window_sprites_index();
+			if (value&4) tbblue_reset_clip_window_ula_index();
+
+        return; // the tbblue_registers[28] is already updated here (do NOT write "value" directly into it)
+
+		case 24:
+			//(W) 0x18 (24) => Clip Window Layer 2
+			clip_window_layer2[tbblue_get_clip_window_layer2_index()]=value;
+            tbblue_inc_clip_window_layer2_index();
+
+			//debug
+			//printf ("layer2 %d %d %d %d\n",clip_window_layer2[0],clip_window_layer2[1],clip_window_layer2[2],clip_window_layer2[3]);
+		return; // the tbblue_registers[24] itself is not used (clip_window_layer2 array contains values)
+
+		case 25:
+			//((W) 0x19 (25) => Clip Window Sprites
+			clip_window_sprites[tbblue_get_clip_window_sprites_index()]=value;
+            tbblue_inc_clip_window_sprites_index();
+
+			//debug
+			//printf ("sprites %d %d %d %d\n",clip_window_sprites[0],clip_window_sprites[1],clip_window_sprites[2],clip_window_sprites[3]);
+		return; // the tbblue_registers[25] itself is not used (clip_window_sprites array contains values)
+
+		case 26:
+			//(W) 0x1A (26) => Clip Window ULA/LoRes
+			clip_window_ula[tbblue_get_clip_window_ula_index()]=value;
+            tbblue_inc_clip_window_ula_index();
+
+			//debug
+			//printf ("ula %d %d %d %d\n",clip_window_ula[0],clip_window_ula[1],clip_window_ula[2],clip_window_ula[3]);
+		return; // the tbblue_registers[26] itself is not used (clip_window_ula array contains values)
+
+    } // switch(index_position)
 
 	tbblue_registers[index_position]=value;
 
@@ -3117,49 +3207,6 @@ void tbblue_set_value_port_position(z80_byte index_position,z80_byte value)
 				if (value&128) screen_print_splash_text(10,ESTILO_GUI_TINTA_NORMAL,ESTILO_GUI_PAPEL_NORMAL,"Enabling lores video mode. 128x96 256 colours");
 				else screen_print_splash_text(10,ESTILO_GUI_TINTA_NORMAL,ESTILO_GUI_PAPEL_NORMAL,"Disabling lores video mode");
 			}
-		break;
-
-
-		case 24:
-			//(W) 0x18 (24) => Clip Window Layer 2
-			clip_window_layer2[clip_window_layer2_index&3]=value;
-			clip_window_layer2_index++;
-
-			//debug
-			//printf ("layer2 %d %d %d %d\n",clip_window_layer2[0],clip_window_layer2[1],clip_window_layer2[2],clip_window_layer2[3]);
-		break;
-
-		case 25:
-			//((W) 0x19 (25) => Clip Window Sprites
-			clip_window_sprites[clip_window_sprites_index&3]=value;
-			clip_window_sprites_index++;
-
-			//debug
-			//printf ("sprites %d %d %d %d\n",clip_window_sprites[0],clip_window_sprites[1],clip_window_sprites[2],clip_window_sprites[3]);
-		break;	
-
-		case 26:
-			//(W) 0x1A (26) => Clip Window ULA/LoRes
-			clip_window_ula[clip_window_ula_index&3]=value;
-			clip_window_ula_index++;
-
-			//debug
-			//printf ("ula %d %d %d %d\n",clip_window_ula[0],clip_window_ula[1],clip_window_ula[2],clip_window_ula[3]);
-		break;				
-
-		case 28:
-		/*
-		(W) 0x1C (28) => Clip Window control
-  bits 7-3 = Reserved, must be 0
-  bit 2 - reset the ULA/LoRes clip index.
-  bit 1 - reset the sprite clip index.
-  bit 0 - reset the Layer 2 clip index.
-  	*/
-
-			if (value&1) clip_window_layer2_index=0;
-			if (value&2) clip_window_sprites_index=0;
-			if (value&4) clip_window_ula_index=0;
-
 		break;
 
 /*
@@ -3338,11 +3385,19 @@ z80_byte tbblue_get_value_port_register(z80_byte registro)
 			return TBBLUE_CORE_VERSION_SUBMINOR;
 		break;		
 
+		case 24:
+			//(W) 0x18 (24) => Clip Window Layer 2
+            return clip_window_layer2[tbblue_get_clip_window_layer2_index()];
+
+		case 25:
+			//((W) 0x19 (25) => Clip Window Sprites
+            return clip_window_sprites[tbblue_get_clip_window_sprites_index()];
+
+		case 26:
+			//(W) 0x1A (26) => Clip Window ULA/LoRes
+			return clip_window_ula[tbblue_get_clip_window_ula_index()];
+
 		/*
-
-
-
-
 		(R) 0x1E (30) => Active video line (MSB)
   bits 7-1 = Reserved, always 0
   bit 0 = Active line MSB (Reset to 0 after a reset)
@@ -3832,7 +3887,6 @@ void screen_store_scanline_rainbow_solo_display_tbblue(void)
 	/* modo lores
 	(R/W) 0x15 (21) => Sprite and Layers system
   bit 7 - LoRes mode, 128 x 96 x 256 colours (1 = enabled)
-  bits 6-5 = Reserved, must be 0
   	*/
 
 	  	int tbblue_lores=tbblue_registers[0x15] & 128;

--- a/src/tbblue.h
+++ b/src/tbblue.h
@@ -176,6 +176,9 @@ extern void tbsprite_pattern_put_value_index(z80_byte sprite,z80_byte index_in_s
 extern z80_byte clip_window_layer2[];
 extern z80_byte clip_window_sprites[];
 extern z80_byte clip_window_ula[];
+extern z80_byte tbblue_get_clip_window_layer2_index(void);
+extern z80_byte tbblue_get_clip_window_sprites_index(void);
+extern z80_byte tbblue_get_clip_window_ula_index(void);
 
 extern z80_bit tbblue_fast_boot_mode;
 

--- a/src/tbblue.h
+++ b/src/tbblue.h
@@ -173,12 +173,16 @@ extern z80_byte tbsprite_pattern_get_value_index(z80_byte sprite,z80_byte index_
 extern void tbsprite_pattern_put_value_index(z80_byte sprite,z80_byte index_in_sprite,z80_byte value);
 
 
-extern z80_byte clip_window_layer2[];
-extern z80_byte clip_window_sprites[];
-extern z80_byte clip_window_ula[];
+#define TBBLUE_CLIP_WINDOW_LAYER2   0
+#define TBBLUE_CLIP_WINDOW_SPRITES  1
+#define TBBLUE_CLIP_WINDOW_ULA      2
+#define TBBLUE_CLIP_WINDOW_TILEMAP  3
+extern z80_byte clip_windows[4][4];
+
 extern z80_byte tbblue_get_clip_window_layer2_index(void);
 extern z80_byte tbblue_get_clip_window_sprites_index(void);
 extern z80_byte tbblue_get_clip_window_ula_index(void);
+extern z80_byte tbblue_get_clip_window_tilemap_index(void);
 
 extern z80_bit tbblue_fast_boot_mode;
 


### PR DESCRIPTION
Updated patch to make clip-window NextRegs (0x18,..,0x1C) to conform to core2.00.26 docs.

The new Tilemap clip window is included (of course it does not clip anything, as there's no Tilemap mode support, but the new NextReg 0x1B is implemented).