### PR TITLE
tbblue: border color picked according to machine settings

### DIFF
--- a/src/screen.c
+++ b/src/screen.c
@@ -4009,10 +4009,6 @@ void screen_store_scanline_rainbow_border_comun(z80_int *puntero_buf_rainbow,int
 
 	z80_byte border_leido;
 
-	//Primer color siempre se define en el array posicion 0
-	//z80_int last_color;
-
-
 	//Para modo interlace
 	int y=t_scanline_draw;
 
@@ -4027,59 +4023,50 @@ void screen_store_scanline_rainbow_border_comun(z80_int *puntero_buf_rainbow,int
 		color_border=screen_return_border_ulaplus_color();
 	}
 
-	if (timex_video_emulation.v) {
+	if (MACHINE_IS_TBBLUE) {
+		//En tbblue, color border depends on several machine settings, has also own Timex mode handling
+		color_border=tbblue_get_border_color(color_border);
+	}
+	else if (timex_video_emulation.v) {
 		z80_byte modo_timex=timex_port_ff&7;
 		if (modo_timex==4 || modo_timex==6) {
 			color_border=get_timex_border_mode6_color();
 		}
 	}
 
-	if (MACHINE_IS_TBBLUE) {
-		//En tbblue, color border depends on several machine settings
-		color_border = tbblue_get_border_color(color_border);
-	}
-
 
 	//Hay que recorrer el array del border para la linea actual
 	int final_border_linea=indice_border+screen_testados_linea;
 	for (;indice_border<final_border_linea;indice_border++) {
-                //obtenemos si hay cambio de border
-                border_leido=fullbuffer_border[indice_border];
-                if (border_leido!=255) {
-                        screen_border_last_color=border_leido;
+		//obtenemos si hay cambio de border
+		border_leido=fullbuffer_border[indice_border];
+		if (border_leido!=255) {
+
+			screen_border_last_color=border_leido;
 			color_border=screen_border_last_color;
 
 			color_border=screen_store_scanline_border_si_incremento_real(color_border);
 
-                        //if (indice_border!=0) printf ("cambio color en indice_border=%d color=%d\n",indice_border,last_color);
-
 			//screen_incremento_border_si_ulaplus();
 			screen_incremento_border_si_spectra();
 
-	                if (ulaplus_presente.v && ulaplus_enabled.v) {
-        	                //color_border=ulaplus_palette_table[screen_border_last_color+8]+ULAPLUS_INDEX_FIRST_COLOR;
-        	                color_border=screen_return_border_ulaplus_color();
-                	}
+			if (ulaplus_presente.v && ulaplus_enabled.v) {
+				//color_border=ulaplus_palette_table[screen_border_last_color+8]+ULAPLUS_INDEX_FIRST_COLOR;
+				color_border=screen_return_border_ulaplus_color();
+			}
 
-			if (timex_video_emulation.v) {
+			if (MACHINE_IS_TBBLUE) {
+					//En tbblue, color border depends on several machine settings, has also own Timex mode handling
+					color_border=tbblue_get_border_color(color_border);
+			}
+			else if (timex_video_emulation.v) {
 				z80_byte modo_timex=timex_port_ff&7;
 				if (modo_timex==4 || modo_timex==6) {
 					color_border=get_timex_border_mode6_color();
 				}
 			}
 
-
-			if (MACHINE_IS_TBBLUE) {
-					//En tbblue, color border depends on several machine settings
-					color_border = tbblue_get_border_color(color_border);
-			}
-
-
-
-
-                }
-
-
+		}
 
 
 		//Si estamos en x a partir del parametro inicial y Si no estamos en zona de retrace horizontal, dibujar border e incrementar posicion

--- a/src/screen.c
+++ b/src/screen.c
@@ -4035,9 +4035,9 @@ void screen_store_scanline_rainbow_border_comun(z80_int *puntero_buf_rainbow,int
 	}
 
 	if (MACHINE_IS_TBBLUE) {
-		//En tbblue, color border empieza en 128
-		color_border=tbblue_get_palette_active_ula(color_border+128)+RGB9_INDEX_FIRST_COLOR;
-	}	
+		//En tbblue, color border depends on several machine settings
+		color_border = tbblue_get_border_color(color_border);
+	}
 
 
 	//Hay que recorrer el array del border para la linea actual
@@ -4069,9 +4069,10 @@ void screen_store_scanline_rainbow_border_comun(z80_int *puntero_buf_rainbow,int
 			}
 
 
-		        if (MACHINE_IS_TBBLUE) {
-                		color_border=tbblue_get_palette_active_ula(color_border)+RGB9_INDEX_FIRST_COLOR;
-		        }
+			if (MACHINE_IS_TBBLUE) {
+					//En tbblue, color border depends on several machine settings
+					color_border = tbblue_get_border_color(color_border);
+			}
 
 
 

--- a/src/tbblue.c
+++ b/src/tbblue.c
@@ -3739,6 +3739,28 @@ void tbblue_set_layer_priorities(void)
 
 }
 
+z80_int tbblue_get_border_color(z80_int color)
+{
+    // 1) pick correct color from active ULA palette (+16, +128 or fallback register)
+    int flash_disabled = tbblue_registers[0x43]&1;  //flash_disabled se llamaba antes. ahora indica "enable ulanext"
+    if (flash_disabled) {   // ULANext mode ON
+        if (255 == tbblue_registers[0x42]) {    // full-ink mode takes border colour from "fallback"
+            color = tbblue_get_9bit_colour(tbblue_registers[0x4A]);
+        }
+        else {  // other ULANext modes take border color from palette starting at 128
+            color = tbblue_get_palette_active_ula(color + 128);
+        }
+    }
+    else {  // ULANext mode OFF (border colors are 16..23)
+        color = tbblue_get_palette_active_ula(color + 16);
+    }
+    // 2) check for transparent colour -> use fallback colour if border is "transparent"
+    if (tbblue_si_transparent(color)) {
+        color = tbblue_get_9bit_colour(tbblue_registers[0x4A]);
+    }
+    return color + RGB9_INDEX_FIRST_COLOR;
+}
+
 void get_pixel_color_tbblue(z80_byte attribute,z80_int *tinta_orig, z80_int *papel_orig)
 {
 

--- a/src/tbblue.c
+++ b/src/tbblue.c
@@ -3742,7 +3742,7 @@ void tbblue_set_layer_priorities(void)
 z80_int tbblue_get_border_color(z80_int color)
 {
     int flash_disabled = tbblue_registers[0x43]&1;  //flash_disabled se llamaba antes. ahora indica "enable ulanext"
-    int is_timex_hires = timex_video_emulation.v && (6 == (timex_port_ff&7));
+    int is_timex_hires = timex_video_emulation.v && ((timex_port_ff&7) == 6);
     // 1) calculate correct color index into palette
 	if (is_timex_hires) {
         // Timex HiRes 512x256 enforces border color by the FF port value, with priority over other methods
@@ -3753,7 +3753,7 @@ z80_int tbblue_get_border_color(z80_int color)
     else if (flash_disabled) {   // ULANext mode ON
 
         //to-be-confirmed core2.00.27 change - commented at this moment
-        //if (255 == tbblue_registers[0x42]) {    // full-ink mode takes border colour from "fallback"
+        //if (tbblue_registers[0x42] == 255) {    // full-ink mode takes border colour from "fallback"
         //    // in this case this is final result, just return it (no further processing needed)
         //    return RGB9_INDEX_FIRST_COLOR + tbblue_get_9bit_colour(tbblue_registers[0x4A]);
         //}

--- a/src/tbblue.c
+++ b/src/tbblue.c
@@ -3739,7 +3739,7 @@ void tbblue_set_layer_priorities(void)
 
 }
 
-unsigned int tbblue_get_border_color(unsigned int color)
+z80_int tbblue_get_border_color(z80_int color)
 {
     int flash_disabled = tbblue_registers[0x43]&1;  //flash_disabled se llamaba antes. ahora indica "enable ulanext"
     int is_timex_hires = timex_video_emulation.v && (6 == (timex_port_ff&7));

--- a/src/tbblue.c
+++ b/src/tbblue.c
@@ -3751,10 +3751,13 @@ unsigned int tbblue_get_border_color(unsigned int color)
         else color += 8 + 16;                       // +8 for BRIGHT 1, +16 for PAPER color in ULANext OFF mode
 	}
     else if (flash_disabled) {   // ULANext mode ON
-        if (255 == tbblue_registers[0x42]) {    // full-ink mode takes border colour from "fallback"
-            // in this case this is final result, just return it (no further processing needed)
-            return RGB9_INDEX_FIRST_COLOR + tbblue_get_9bit_colour(tbblue_registers[0x4A]);
-        }
+
+        //to-be-confirmed core2.00.27 change - commented at this moment
+        //if (255 == tbblue_registers[0x42]) {    // full-ink mode takes border colour from "fallback"
+        //    // in this case this is final result, just return it (no further processing needed)
+        //    return RGB9_INDEX_FIRST_COLOR + tbblue_get_9bit_colour(tbblue_registers[0x4A]);
+        //}
+
         // other ULANext modes take border color from palette starting at 128..135
         color += 128;
     }

--- a/src/tbblue.h
+++ b/src/tbblue.h
@@ -149,6 +149,7 @@ extern z80_byte tbblue_get_port_sprite_index(void);
 extern z80_int tbblue_get_palette_active_layer2(z80_byte index);
 
 extern z80_int tbblue_get_palette_active_ula(z80_byte index);
+extern z80_int tbblue_get_border_color(z80_int color);
 
 extern z80_byte tbblue_port_123b;
 extern int tbblue_write_on_layer2(void);

--- a/src/tbblue.h
+++ b/src/tbblue.h
@@ -149,7 +149,7 @@ extern z80_byte tbblue_get_port_sprite_index(void);
 extern z80_int tbblue_get_palette_active_layer2(z80_byte index);
 
 extern z80_int tbblue_get_palette_active_ula(z80_byte index);
-extern unsigned int tbblue_get_border_color(unsigned int color);
+extern z80_int tbblue_get_border_color(z80_int color);
 
 extern z80_byte tbblue_port_123b;
 extern int tbblue_write_on_layer2(void);

--- a/src/tbblue.h
+++ b/src/tbblue.h
@@ -149,7 +149,7 @@ extern z80_byte tbblue_get_port_sprite_index(void);
 extern z80_int tbblue_get_palette_active_layer2(z80_byte index);
 
 extern z80_int tbblue_get_palette_active_ula(z80_byte index);
-extern z80_int tbblue_get_border_color(z80_int color);
+extern unsigned int tbblue_get_border_color(unsigned int color);
 
 extern z80_byte tbblue_port_123b;
 extern int tbblue_write_on_layer2(void);


### PR DESCRIPTION
+ ULA first/second palette supported
+ ULANext ON/OFF supported
+ global transparency resolved on border
+ ULANext-ON "full-ink" mode will use transparency fallback register
(core 2.00.27 change)