### PR TITLE
Scale glViewport for retina displays.

### DIFF
--- a/src/scrcocoa.m
+++ b/src/scrcocoa.m
@@ -161,6 +161,7 @@ UInt8 *pixel_screen_data;
 NSInteger pixel_screen_width;
 NSInteger pixel_screen_height;
 
+NSRect vprect;
 
 // keymap conversion
 
@@ -516,6 +517,9 @@ int pendiente_z88_draw_lower=0;
 
         pixel_screen_height = screen_get_window_size_height_zoom_border_en();
 
+        // Convert screen width & height to their backing store coordinates
+        vprect = [normalWindow convertRectToBacking:NSMakeRect(0, 0, pixel_screen_width, pixel_screen_height)];
+
         NSInteger dataLength = pixel_screen_width * pixel_screen_height * 4;
         pixel_screen_data = (UInt8*)malloc(dataLength * sizeof(UInt8));
 
@@ -649,10 +653,7 @@ int pendiente_z88_draw_lower=0;
 
         [[self openGLContext] makeCurrentContext];
 
-
-        glViewport(0,0,pixel_screen_width, pixel_screen_height);
-
-
+        glViewport(0, 0, vprect.size.width, vprect.size.height);
 
         //NO BORRAMOS el fondo porque ya lo dibujamos más abajo
 
@@ -2857,7 +2858,8 @@ int scrcocoa_init (void) {
         pixel_screen_width = screen_get_window_size_width_zoom_border_en()+screen_get_ext_desktop_width_zoom();
         pixel_screen_height = screen_get_window_size_height_zoom_border_en();
 
-   
+        // Convert screen width & height to their backing store coordinates
+        vprect = [normalWindow convertRectToBacking:NSMakeRect(0, 0, pixel_screen_width, pixel_screen_height)];
 
 //screen_get_window_size_width_zoom_border_en(), screen_get_window_size_height_zoom_border_en()
 


### PR DESCRIPTION
I came across an issue in the cocoa display driver where the emulated screen occupies only the bottom left quarter of the window - I think this is currently mentioned in TODO_this_version, and I believe is specific to Mac retina displays.

I saw that there is the start of an alternative putpixel method (`retina_scrcocoa_putpixel_final_rgb`) for retina displays - but I believe there is a very simple way to scale the screen up to the appropriate 'retina' scaling factor using `convertRectToBacking`, and setting `glViewport` appropriately in the `render` method. I can see that you may want more control in the putpixel method instead - but this change was so small that I thought I'd submit a pull request and see what you think.