### PR TITLE
os-detection: fix OS name detection on Armbian

### DIFF
--- a/src/configure
+++ b/src/configure
@@ -445,7 +445,7 @@ fi
 SISTEMA_RELEASE="$SISTEMA"
 
 if [ -e /etc/os-release ]; then
-	SISTEMA_RELEASE=`cat /etc/os-release |grep PRETTY_NAME|cut -d '"' -f2`
+	SISTEMA_RELEASE=`cat /etc/os-release |grep PRETTY_NAME| head -n1 |cut -d '"' -f2`
 fi
 
 echo -n "Checking for $CCOMPILER compiler ... "


### PR DESCRIPTION
Armbian has the 2 lines containing `PRETTY_NAME` in `/etc/os-release` and this leads to a multi-line variable in `compileoptions.h`. This, in turn, breaks the build since `COMPILATION_SYSTEM_RELEASE` will span 2 lines.

Fix the build error by limiting the `/etc/os-release` output to just the 1st line, so `COMPILATION_SYSTEM_RELEASE` will doesn't spill on the next line.

NB: The `compileoptions.h` will contain - after `configure` is run - something like:
```
...
#define COMPILATION_SYSTEM "GNU/Linux"
#define COMPILATION_SYSTEM_RELEASE "Armbian_community 25.5.0-trunk.4 noble
Armbian_community 25.5.0-trunk.4 noble"
... 
```
Originally reported by a RetroPie user in https://retropie.org.uk/forum/topic/36955/zesarux-12-pi5-arm64-fails-to-compile/6.