### PR TITLE
Fix attribute column artifacts on multicolor effects (Nirvana) with realvideo

### DIFF
--- a/src/contend.c
+++ b/src/contend.c
@@ -1594,9 +1594,14 @@ z80_byte *contend_table_no_mreq;
 	if (MACHINE_IS_SPECTRUM_P2A_P3) {
 		//+2A
                 timings=contend_patron_76543210;
-                offset_time=-1;
+
+		//Patron 1,0,7,6,5,4,3,2 comenzando en 14361, igual inicio que el 128k
+		//Segun http://www.worldofspectrum.org/faq/reference/128kreference.htm#Plus3
+		//Antes habia offset_time=-1 (inicio en 14365): era el valor antiguo sin corregir,
+		//el branch de 128k si recibio en su dia la correccion equivalente de -1 a 3.
+		//El desfase de 4 T-estados hacia parpadear columnas en efectos multicolor (Nirvana) en +2A/+3
+                offset_time=3;
                 offset_patron=4;
-		//Empieza en 14365 con 1076543210  Segun http://www.worldofspectrum.org/faq/reference/128kreference.htm#Plus3
 
 	}
 

--- a/src/cores/core_spectrum.c
+++ b/src/cores/core_spectrum.c
@@ -188,8 +188,29 @@ void interrupcion_si_despues_lda_ir(void)
 
 
 
+//Linea (t_scanline_draw) a la que corresponde el valor actual de last_x_atributo.
+//Permite distinguir un cambio de linea real de dos syncs consecutivos en la misma celda
+static int rainbow_ultima_linea_almacenada=-1;
+
+//Celdas pre-latcheadas del principio de la linea SIGUIENTE.
+//Cuando un poke a pantalla aterriza justo despues de cruzar el final de linea (t_estados ya en la
+//linea siguiente pero t_scanline_draw aun sin avanzar), no podemos escribir en scanline_buffer
+//porque aun contiene la linea anterior pendiente de renderizar. Guardamos aqui los pares
+//(pixel,atributo) de las primeras celdas con la memoria PREVIA a la escritura, y se vuelcan
+//al buffer cuando se detecta el cambio de linea
+#define RAINBOW_PENDING_MAX 16
+static z80_byte rainbow_pending_prefix[RAINBOW_PENDING_MAX*2];
+static int rainbow_pending_count=0;
+static int rainbow_pending_linea=-1;
+
 void core_spectrum_store_rainbow_current_atributes(void)
 {
+
+	//Offset en T-estados del prefetch de la ULA respecto al modelo t%linea==0 -> celda 0.
+	//En el modelo de zesarux el instante 0 de cada linea ya corresponde al inicio del fetch
+	//de la ULA (la contencion 128k empieza en 14361 y el paper en 14364 = linea 63*228),
+	//por lo que no debe aplicarse offset adicional (se probo con 8 y no mejoraba)
+#define ULA_PREFETCH_OFFSET_TSTATES 0
 
 	//No hacer esto en tbblue
 	if (MACHINE_IS_TBBLUE && tbblue_store_scanlines.v==0) return;
@@ -229,7 +250,10 @@ void core_spectrum_store_rainbow_current_atributes(void)
     //como esto es muy costoso, hacemos que se guardan los atributos leidos desde el opcode anterior hasta este
     if (rainbow_enabled.v) {
         if (t_scanline_draw>=screen_indice_inicio_pant && t_scanline_draw<screen_indice_fin_pant) {
-            int atributo_pos=(t_estados % screen_testados_linea)/4;
+            //Sumamos el offset de prefetch de la ULA: latch de cada celda unos T-estados antes de mostrarse
+            int atributo_pos=((t_estados % screen_testados_linea)+ULA_PREFETCH_OFFSET_TSTATES)/4;
+            //Proteccion contra desbordamiento del buffer cerca del final de linea (zona border)
+            if (atributo_pos>=SCANLINEBUFFER_ONE_ARRAY_LENGTH/2) atributo_pos=SCANLINEBUFFER_ONE_ARRAY_LENGTH/2-1;
             z80_byte *screen_atributo=get_base_mem_pantalla_attributes();
             z80_byte *screen_pixel=get_base_mem_pantalla();
 
@@ -249,33 +273,95 @@ void core_spectrum_store_rainbow_current_atributes(void)
 
             int dir_pixel=screen_addr_table[(t_scanline_draw-screen_indice_inicio_pant)*32];
 
-            //si hay cambio de linea, empezamos con el 0
-            //puede parecer que al cambiar de linea nos perdemos el ultimo atributo de pantalla hasta el primero de la linea
-            //siguiente, pero eso es imposible, dado que eso sucede desde el ciclo 128 hasta el 228 (zona de borde)
-            // y no hay ningun opcode que tarde 100 ciclos
-            if (last_x_atributo>atributo_pos) last_x_atributo=0;
+            //Cambio de linea: reiniciamos el puntero de celda SOLO cuando t_scanline_draw avanza.
+            //Antes se reiniciaba cuando last_x_atributo>atributo_pos, pero desde que el buffer se
+            //sincroniza en cada escritura a pantalla (poke_byte_spectrum_sync_rainbow) pueden llegar
+            //dos syncs dentro de la misma celda de 4 T-estados (ej: los dos bytes de un PUSH).
+            //El reset erroneo a 0 releia toda la linea desde la celda 0 con la memoria ya modificada,
+            //aplicando retroactivamente los atributos nuevos a celdas que la ULA ya habia leido
+            //(columnas de atributos incorrectos en efectos multicolor tipo Nirvana)
+            if (t_scanline_draw!=rainbow_ultima_linea_almacenada) {
+                rainbow_ultima_linea_almacenada=t_scanline_draw;
+                last_x_atributo=0;
+
+                //Si hay celdas pre-latcheadas de esta linea (poke tras cruzar el final de la anterior),
+                //volcarlas al buffer: contienen los valores previos a esa escritura
+                if (rainbow_pending_count>0) {
+                    if (rainbow_pending_linea==t_scanline_draw) {
+                        memcpy(scanline_buffer,rainbow_pending_prefix,rainbow_pending_count*2);
+                        last_x_atributo=rainbow_pending_count;
+                    }
+                    rainbow_pending_count=0;
+                }
+            }
+
+            //Si ya hemos almacenado hasta atributo_pos en esta linea, no hay nada que hacer.
+            //Sucede con un segundo sync dentro de la misma celda de 4 T-estados, o con un poke
+            //justo despues de cruzar el final de linea (t_estados ya esta en la linea siguiente
+            //pero t_scanline_draw aun no ha avanzado): en ese caso NO hay que tocar el buffer,
+            //que aun contiene la linea anterior pendiente de renderizar
+            if (last_x_atributo<=atributo_pos) {
+
                 dir_atributo += last_x_atributo;
                 dir_pixel +=last_x_atributo;
 
-            //Puntero al buffer de atributos
-            z80_byte *puntero_buffer;
-            puntero_buffer=&scanline_buffer[last_x_atributo*2];
+                //Puntero al buffer de atributos
+                z80_byte *puntero_buffer;
+                puntero_buffer=&scanline_buffer[last_x_atributo*2];
 
-            for (;last_x_atributo<=atributo_pos;last_x_atributo++) {
-                //printf ("last_x_atributo: %d atributo_pos: %d\n",last_x_atributo,atributo_pos);
-                last_ula_pixel=screen_pixel[dir_pixel];
-                last_ula_attribute=screen_atributo[dir_atributo];
+                for (;last_x_atributo<=atributo_pos;last_x_atributo++) {
+                    //printf ("last_x_atributo: %d atributo_pos: %d\n",last_x_atributo,atributo_pos);
+                    last_ula_pixel=screen_pixel[dir_pixel];
+                    last_ula_attribute=screen_atributo[dir_atributo];
 
-                //realmente en este array guardamos tambien atributo cuando estamos en la zona de border,
-                //nos da igual, lo hacemos por no complicarlo
-                //debemos tambien suponer que atributo_pos nunca sera mayor o igual que ATRIBUTOS_ARRAY_LENGTH
-                //esto debe ser asi dado que atributo_pos=(t_estados % screen_testados_linea)/4;
+                    //realmente en este array guardamos tambien atributo cuando estamos en la zona de border,
+                    //nos da igual, lo hacemos por no complicarlo
+                    //debemos tambien suponer que atributo_pos nunca sera mayor o igual que ATRIBUTOS_ARRAY_LENGTH
+                    //esto debe ser asi dado que atributo_pos=(t_estados % screen_testados_linea)/4;
 
-                *puntero_buffer++=last_ula_pixel;
-                *puntero_buffer++=last_ula_attribute;
-                dir_atributo++;
-                dir_pixel++;
+                    *puntero_buffer++=last_ula_pixel;
+                    *puntero_buffer++=last_ula_attribute;
+                    dir_atributo++;
+                    dir_pixel++;
+                }
             }
+
+            //Poke tras cruzar el final de linea: t_estados ya esta en la linea siguiente pero
+            //t_scanline_draw aun no ha avanzado (fin_scanline se ejecuta al acabar el opcode).
+            //No podemos tocar scanline_buffer (linea anterior pendiente de renderizar), pero si
+            //debemos capturar las primeras celdas de la linea siguiente ANTES de la escritura,
+            //porque la ULA ya las habria leido. Se vuelcan al detectar el cambio de linea
+            else if ((int)(t_estados/screen_testados_linea)>t_scanline) {
+                int linea_sig=t_scanline_draw+1;
+                if (linea_sig>=screen_indice_inicio_pant && linea_sig<screen_indice_fin_pant) {
+
+                    int dir_atributo_sig;
+                    if (timex_si_modo_8x1()) {
+                        dir_atributo_sig=screen_addr_table[(linea_sig-screen_indice_inicio_pant)*32];
+                    }
+                    else {
+                        dir_atributo_sig=(linea_sig-screen_indice_inicio_pant)/8;
+                        dir_atributo_sig *=32;
+                    }
+
+                    int dir_pixel_sig=screen_addr_table[(linea_sig-screen_indice_inicio_pant)*32];
+
+                    //Si el pending era de otra linea (stale por frameskip), descartarlo
+                    if (rainbow_pending_linea!=linea_sig) {
+                        rainbow_pending_count=0;
+                        rainbow_pending_linea=linea_sig;
+                    }
+
+                    int i;
+                    for (i=rainbow_pending_count;i<=atributo_pos && i<RAINBOW_PENDING_MAX;i++) {
+                        rainbow_pending_prefix[i*2]=screen_pixel[dir_pixel_sig+i];
+                        rainbow_pending_prefix[i*2+1]=screen_atributo[dir_atributo_sig+i];
+                    }
+                    if (i>rainbow_pending_count) rainbow_pending_count=i;
+                }
+            }
+
+            //else: segundo sync dentro de la misma celda de 4 T-estados: nada que hacer
 
             //Siguiente posicion se queda en last_x_atributo
 

--- a/src/operaciones.c
+++ b/src/operaciones.c
@@ -49,6 +49,7 @@
 #include "spectra.h"
 #include "spritechip.h"
 #include "jupiterace.h"
+#include "core_spectrum.h"
 #include "chloe.h"
 #include "prism.h"
 #include "timex.h"
@@ -615,9 +616,26 @@ z80_byte fetch_opcode_vacio(void)
 
 
 
+
+//Sincronizar el buffer rainbow de la ULA antes de una escritura en la zona de pantalla/atributos,
+//para que las celdas que la ULA real ya habia leido conserven el valor anterior a la escritura.
+//Sin esto, el valor nuevo se aplicaba retroactivamente a todas las celdas leidas durante el opcode,
+//produciendo columnas de atributos incorrectas en efectos multicolor (Nirvana, etc)
+static inline void poke_byte_spectrum_sync_rainbow(z80_int dir)
+{
+        if (rainbow_enabled.v) {
+                //0x4000-0x7FFF: banco 5 (pantalla normal en 128k, pantalla en 48k)
+                //0xC000-0xFFFF: en 128k es el banco paginado, que puede ser el banco de pantalla (5 o 7)
+                if ( (dir&49152)==16384 || dir>=49152 ) {
+                        core_spectrum_store_rainbow_current_atributes();
+                }
+        }
+}
+
 void poke_byte_no_time_spectrum_48k(z80_int dir,z80_byte valor)
 {
         if (dir>16383) {
+		poke_byte_spectrum_sync_rainbow(dir);
 		memoria_spectrum[dir]=valor;
 
 #ifdef EMULATE_VISUALMEM
@@ -641,6 +659,7 @@ void poke_byte_spectrum_48k(z80_int dir,z80_byte valor)
 
 
         if (dir>16383) {
+		poke_byte_spectrum_sync_rainbow(dir);
 #ifdef EMULATE_VISUALMEM
 
 set_visualmembuffer(dir);
@@ -679,6 +698,7 @@ z80_byte *puntero;
                 segmento=dir / 16384;
 
         if (dir>16383) {
+		poke_byte_spectrum_sync_rainbow(dir);
 #ifdef EMULATE_VISUALMEM
 
 set_visualmembuffer(dir);
@@ -711,6 +731,7 @@ z80_byte *puntero;
 
 
         if (dir>16383) {
+		poke_byte_spectrum_sync_rainbow(dir);
 #ifdef EMULATE_VISUALMEM
 
 set_visualmembuffer(dir);
@@ -731,6 +752,7 @@ z80_byte *puntero;
                 segmento=dir / 16384;
 
         if (dir>16383) {
+		poke_byte_spectrum_sync_rainbow(dir);
 #ifdef EMULATE_VISUALMEM
 
 set_visualmembuffer(dir);
@@ -777,6 +799,7 @@ z80_byte *puntero;
 
 
         if (dir>16383) {
+		poke_byte_spectrum_sync_rainbow(dir);
 #ifdef EMULATE_VISUALMEM
 
 set_visualmembuffer(dir);


### PR DESCRIPTION
## Problem

With `--realvideo` (rainbow render), games using Nirvana-style multicolor engines show wrong attribute columns (vertical bands with incorrect colors). Reproducible with any Nirvana/Nirvana+ engine game on 48k, 128k, +2, +2A and +3.

## Root cause

`core_spectrum_store_rainbow_current_atributes()` is only called once per opcode (catch-up from `last_x_atributo` to the current cell). If an opcode writes to screen/attribute memory mid-execution, the new value is applied **retroactively** to ULA cells already latched with the old value. The code comment already admitted this was not exact.

Two additional issues found while fixing:

- The line-change detection (`last_x_atributo > atributo_pos`) misfires once the buffer is synced on every screen write: two syncs inside the same 4T cell (e.g. both bytes of a PUSH) wrongly restarted the whole line with already-modified memory.
- +2A/+3 contention started 4T late (`offset_time=-1`, i.e. 14365 instead of 14361 like the 128k, per the worldofspectrum.org 128k reference), causing flickering columns on +2A/+3.

## Changes

- **operaciones.c**: new `poke_byte_spectrum_sync_rainbow()` helper, called right before any write to screen memory (0x4000-0x7FFF and the paged bank at 0xC000-0xFFFF, which may hold the shadow screen) in the 48k/128k/+2A poke functions and their no_time variants. Near-zero cost: only active with rainbow enabled and writes to the screen area.
- **core_spectrum.c**: reset `last_x_atributo` on real scanline change (`t_scanline_draw`) instead of `last_x_atributo > atributo_pos`; cells pre-latched just after a line crossing (when `t_estados` is already on the next line but `t_scanline_draw` has not advanced yet) are buffered and flushed when the line change is detected. Also documents why no ULA prefetch offset is needed (tested with 8T, no improvement).
- **contend.c**: +2A/+3 contention `offset_time` -1 -> 3 (starts at 14361, same as 128k).

## Testing

Tested with Nirvana-engine games (128k and 48k versions) on emulated 48k, 128k, +2, +2A and +3: attribute columns now render correctly on all of them.